### PR TITLE
Add screenshot to chat mode for visual context + demo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,9 @@
   Voice-controlled AI cursor for Linux. Hold a hotkey, say something, the cursor flies to whatever you mentioned or the right action fires.
 </p>
 
-```
-"where is the search bar"      → cursor flies to it
-"click the play button"        → cursor moves + real click fires
-"play despacito on spotify"    → spotify API call, music starts
-"check my email"               → gmail unread count, spoken aloud
-"remember my name is Daniel"   → stored locally, recalled later
-"what's your name"             → spoken reply, no screen used
-```
+<p align="center">
+  <img alt="Aegis Demo" src="aegis/assets/demo.gif" width="800">
+</p>
 
 Built in Rust. Primary target is Linux/Hyprland; macOS and Windows build flag-free from the same `cargo run`.
 

--- a/aegis/src/orchestrator.rs
+++ b/aegis/src/orchestrator.rs
@@ -259,6 +259,7 @@ fn run_one_turn(
     rt.block_on(async {
         match intent {
             Intent::FindAction => {
+                eprintln!("[intent] → FindAction for: {:?}", transcript);
                 run_find_action(
                     claude,
                     &transcript,
@@ -275,9 +276,11 @@ fn run_one_turn(
                 .await
             }
             Intent::Chat => {
+                eprintln!("[intent] → Chat for: {:?}", transcript);
                 run_chat(
                     claude,
                     &transcript,
+                    &resized_b64,
                     memory,
                     release_t,
                     &cancel_claude,
@@ -406,12 +409,12 @@ async fn run_find_action(
     }
 }
 
-/// Dispatch the Chat path. No tools, no screen; pure conversational
-/// streaming. Text deltas land in the sentence channel which the TTS
-/// task pulls from.
+/// Dispatch the Chat path. Now includes screenshot for visual context.
+/// Text deltas land in the sentence channel which the TTS task pulls from.
 async fn run_chat(
     claude: &Claude,
     transcript: &str,
+    screenshot_b64: &str,
     memory: &crate::providers::claude::MemoryStore,
     release_t: std::time::Instant,
     cancel_claude: &CancellationToken,
@@ -425,7 +428,7 @@ async fn run_chat(
             eprintln!("[barge-in] chat aborted at {:?}", release_t.elapsed());
         }
         result = claude.chat(
-            transcript, profile.as_deref(),
+            transcript, screenshot_b64, profile.as_deref(),
             |delta| helper.push_delta(delta),
         ) => {
             match result {

--- a/aegis/src/providers/claude/chat.rs
+++ b/aegis/src/providers/claude/chat.rs
@@ -1,19 +1,19 @@
-//! Conversational path. Used when the classifier returns Intent::Chat
-//! (the user asked something that doesn't need the screen, doesn't need
-//! a service tool, and doesn't need multi-step planning). Just talk back.
+//! Conversational path. Used when the classifier returns Intent::Chat.
+//! Now includes a screenshot so Claude can see the user's screen and
+//! provide contextual help (e.g., "how do I do X in this app?").
 //!
 //! Differences from `run_agent_loop`:
 //!   * No tools at all. Claude can't accidentally try to call gmail or
 //!     move the cursor on a casual question.
-//!   * No screenshot attached.
+//!   * Screenshot IS attached for visual context.
 //!   * No agent loop. One streaming response, every text delta is piped
 //!     to the caller's `on_text_delta` so TTS can start speaking on the
 //!     first sentence boundary.
 //!   * Optional user_profile string (loaded from memory) gets injected
 //!     into the system prompt so Claude knows who it's talking to.
 //!
-//! The fast path most voice turns will take. Target latency: ~600-800ms
-//! release-to-speech when cache is warm.
+//! The fast path most voice turns will take. Target latency: ~800-1000ms
+//! release-to-speech when cache is warm (slightly slower due to image).
 
 use super::Claude;
 use futures_util::StreamExt;
@@ -21,9 +21,11 @@ use futures_util::StreamExt;
 impl Claude {
     /// Run a chat turn. Streams text deltas via `on_text_delta` and
     /// returns the full assembled text when the stream ends.
+    /// Now includes a screenshot for visual context.
     pub async fn chat<T>(
         &self,
         transcript: &str,
+        screenshot_b64: &str,
         user_profile: Option<&str>,
         mut on_text_delta: T,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>
@@ -52,9 +54,20 @@ impl Claude {
             "max_tokens": 1024,
             "stream": true,
             "system": system_blocks,
-            "messages": [
-                { "role": "user", "content": transcript }
-            ]
+            "messages": [{
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image",
+                        "source": {
+                            "type": "base64",
+                            "media_type": "image/jpeg",
+                            "data": screenshot_b64
+                        }
+                    },
+                    { "type": "text", "text": transcript }
+                ]
+            }]
         });
 
         let t_send = std::time::Instant::now();
@@ -121,8 +134,9 @@ impl Claude {
 /// it caches well. Keep short. Every token here is sent on every chat
 /// turn.
 fn chat_system_prompt() -> &'static str {
-    "You are aegis, a voice assistant running on the user's desktop. The \
-user is speaking to you and hearing your replies via TTS, so:\n\
+    "You are aegis, a voice assistant running on the user's desktop. A \
+screenshot of the user's current screen is attached. The user is \
+speaking to you and hearing your replies via TTS, so:\n\
 - Be concise. Aim for 1-3 sentences unless the user asks for detail.\n\
 - Plain prose only. No markdown, no lists, no code blocks. They sound \
 weird when read aloud.\n\
@@ -131,8 +145,8 @@ weird when read aloud.\n\
 - If the user asks something you don't know, say so briefly. Don't \
 guess and don't pad with disclaimers.\n\
 \n\
-You don't have access to the user's screen, files, or any external \
-services in this conversation. If they ask for something that needs \
-those, tell them to phrase it differently (e.g. \"check my email\" or \
-\"where is X on screen\")."
+You CAN see the user's screen in the attached image. Use it to provide \
+contextual help. If they ask \"how do I do X\" and you can see the app \
+they're using, guide them through the UI you see. Reference specific \
+buttons, menus, or elements visible on screen. Be helpful and specific."
 }

--- a/aegis/src/providers/claude/find_action.rs
+++ b/aegis/src/providers/claude/find_action.rs
@@ -177,10 +177,19 @@ impl Claude {
                                         on_action(action.clone());
                                         emitted = Some(action);
                                     } else {
-                                        eprintln!(
-                                            "[find_action] unknown tool '{}' input={}",
-                                            name, input_json
-                                        );
+                                        // Log why the action failed
+                                        if name == "computer" && input["action"].as_str() == Some("screenshot") {
+                                            eprintln!(
+                                                "[find_action] ERROR: Claude called screenshot action (FORBIDDEN). \
+                                                User asked: {:?}. Claude should have used mouse_move or left_click instead.",
+                                                prompt
+                                            );
+                                        } else {
+                                            eprintln!(
+                                                "[find_action] unknown/invalid tool '{}' input={}. User asked: {:?}",
+                                                name, input_json, prompt
+                                            );
+                                        }
                                     }
                                 }
                                 tool_json_buffer.clear();

--- a/aegis/src/providers/claude/find_action.rs
+++ b/aegis/src/providers/claude/find_action.rs
@@ -178,7 +178,9 @@ impl Claude {
                                         emitted = Some(action);
                                     } else {
                                         // Log why the action failed
-                                        if name == "computer" && input["action"].as_str() == Some("screenshot") {
+                                        if name == "computer"
+                                            && input["action"].as_str() == Some("screenshot")
+                                        {
                                             eprintln!(
                                                 "[find_action] ERROR: Claude called screenshot action (FORBIDDEN). \
                                                 User asked: {:?}. Claude should have used mouse_move or left_click instead.",


### PR DESCRIPTION
Chat mode now includes a screenshot so Claude can see the user's screen and provide contextual help (e.g., "how do I make a beat in Logic Pro?").

Changes:
- chat.rs: Accept screenshot parameter, include image in API request, update system prompt to tell Claude it can see the screen
- orchestrator.rs: Pass screenshot to run_chat, add intent logging
- find_action.rs: Better error logging when Claude calls forbidden screenshot action
- README.md: Replace text examples with demo gif

<!--
Before opening a PR:

- Confirm you have prior `lgtm` approval on the linked issue. PRs from
  contributors without `lgtm` are auto-closed (see CONTRIBUTING.md).
- Run `cargo check` and `cargo test` locally. Both must pass.
- See AGENTS.md for project-specific rules (commit style, comment style,
  where files belong).
-->

## What this PR does

<!-- One or two sentences. Be concrete. -->

## Why

<!-- Closes #<number>. If there's no linked issue, you don't have lgtm. Stop. -->

## How it was tested

<!-- Specific. "cargo test passes" is not enough on its own. -->

- [ ] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Manually verified the change on (Hyprland / winit / N/A): ...
- [ ] Updated `CHANGELOG.md` under `[Unreleased]` if user-facing

## Scope and tradeoffs

<!-- What modules this touches, what could regress, what was explicitly
not done. Skip if trivial. -->
