### PR TITLE
Fix macOS release hang: notarize the dmg out-of-band with a bounded wait

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,9 @@ jobs:
     # separate macos-13 job. Skipping for now: most new Macs are arm64,
     # and we can add x86_64 later if anyone asks for it.
     runs-on: macos-latest
+    # Backstop so a wedged step can't burn the full 6h GitHub job cap.
+    # Notarization itself is bounded separately (notarytool --timeout below).
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
@@ -166,9 +169,6 @@ jobs:
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
           echo "$APPLE_CERTIFICATE" | base64 --decode > certificate.p12
@@ -189,27 +189,29 @@ jobs:
             echo "::error::No 'Developer ID Application' identity in the imported certificate."
             exit 1
           fi
-          # Export signing + notarization vars for the build step. These are
-          # only set on this (signing) path; otherwise they stay ABSENT so
-          # Tauri builds unsigned. Setting APPLE_SIGNING_IDENTITY to an empty
-          # string is NOT the same as unset — Tauri would try to sign with ""
-          # and fail, so we must only define it when actually signing.
+          # Export ONLY the signing identity for the build step. We deliberately
+          # do NOT export APPLE_ID / APPLE_PASSWORD / APPLE_TEAM_ID here: their
+          # presence is what makes `cargo tauri build` notarize inline (a
+          # notarytool submit --wait with no timeout, which is what wedged the
+          # job for ~6h). With them absent Tauri signs but skips notarization,
+          # and we notarize the .dmg ourselves below with a bounded wait.
+          # Setting APPLE_SIGNING_IDENTITY to an empty string is NOT the same as
+          # unset — Tauri would try to sign with "" and fail, so we only define
+          # it when actually signing.
           echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
-          echo "APPLE_ID=$APPLE_ID" >> "$GITHUB_ENV"
-          echo "APPLE_PASSWORD=$APPLE_PASSWORD" >> "$GITHUB_ENV"
-          echo "APPLE_TEAM_ID=$APPLE_TEAM_ID" >> "$GITHUB_ENV"
           echo "Signing identity: $CERT_ID"
 
       # Tauri's build.rs in launcher/src-tauri copies the aegis binary with the
       # right target-triple suffix, then `cargo tauri build` bundles it as a
-      # sidecar inside Aegis.app and produces a .dmg. If the signing vars were
-      # exported above (secrets present) Tauri signs + notarizes; otherwise
-      # APPLE_SIGNING_IDENTITY is "-" from the detect step, so it ad-hoc signs.
+      # sidecar inside Aegis.app and produces a .dmg. With a real Developer ID
+      # identity Tauri signs (hardened runtime); with APPLE_SIGNING_IDENTITY="-"
+      # from the detect step it ad-hoc signs. Notarization is intentionally a
+      # separate step below, not done here.
       - name: Build launcher .app + .dmg
         working-directory: launcher
         run: cargo tauri build
 
-      - name: Package artifact
+      - name: Locate .dmg
         run: |
           mkdir -p dist
           # Cargo workspace: the bundle lands in the workspace-root target dir
@@ -222,6 +224,51 @@ jobs:
             exit 1
           fi
           cp "$DMG" dist/aegis-macos-aarch64.dmg
+
+      # Notarize the signed .dmg ourselves instead of letting `cargo tauri
+      # build` do it inline. notarytool's default wait is unbounded — that's
+      # what hung the job for ~6h. --timeout fails the submit in minutes if
+      # Apple's notary queue is stuck, and on any non-Accepted result we pull
+      # the notary log so the reason shows up in the run. Stapling writes the
+      # ticket into the .dmg so it validates offline (no Gatekeeper network
+      # round-trip on first open). Skipped on the unsigned path (DO_SIGN=false).
+      - name: Notarize and staple .dmg
+        if: env.DO_SIGN == 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          DMG=dist/aegis-macos-aarch64.dmg
+          # Don't let the default -e abort before we can read the status/log.
+          set +e
+          OUT=$(xcrun notarytool submit "$DMG" \
+            --apple-id "$APPLE_ID" \
+            --password "$APPLE_PASSWORD" \
+            --team-id "$APPLE_TEAM_ID" \
+            --wait --timeout 30m \
+            --output-format json)
+          RC=$?
+          set -e
+          echo "$OUT"
+          ID=$(echo "$OUT" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("id",""))' 2>/dev/null || true)
+          STATUS=$(echo "$OUT" | python3 -c 'import sys,json;print(json.load(sys.stdin).get("status",""))' 2>/dev/null || true)
+          if [ "$STATUS" != "Accepted" ]; then
+            echo "::error::Notarization failed (status='$STATUS', notarytool exit=$RC)."
+            if [ -n "$ID" ]; then
+              echo "----- notary log $ID -----"
+              xcrun notarytool log "$ID" \
+                --apple-id "$APPLE_ID" --password "$APPLE_PASSWORD" --team-id "$APPLE_TEAM_ID" || true
+            fi
+            exit 1
+          fi
+          xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
+
+      # Checksum AFTER stapling: stapling rewrites the .dmg, so hashing earlier
+      # would publish a hash that doesn't match the shipped file.
+      - name: Checksum artifact
+        run: |
           (cd dist && shasum -a 256 aegis-macos-aarch64.dmg > aegis-macos-aarch64.dmg.sha256)
 
       - name: Attest macOS artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,7 +196,7 @@ jobs:
           # job for ~6h). With them absent Tauri signs but skips notarization,
           # and we notarize the .dmg ourselves below with a bounded wait.
           # Setting APPLE_SIGNING_IDENTITY to an empty string is NOT the same as
-          # unset — Tauri would try to sign with "" and fail, so we only define
+          # unset. Tauri would try to sign with "" and fail, so we only define
           # it when actually signing.
           echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> "$GITHUB_ENV"
           echo "Signing identity: $CERT_ID"
@@ -226,7 +226,7 @@ jobs:
           cp "$DMG" dist/aegis-macos-aarch64.dmg
 
       # Notarize the signed .dmg ourselves instead of letting `cargo tauri
-      # build` do it inline. notarytool's default wait is unbounded — that's
+      # build` do it inline. notarytool's default wait is unbounded, which is
       # what hung the job for ~6h. --timeout fails the submit in minutes if
       # Apple's notary queue is stuck, and on any non-Accepted result we pull
       # the notary log so the reason shows up in the run. Stapling writes the

--- a/aegis/src/providers/claude/mod.rs
+++ b/aegis/src/providers/claude/mod.rs
@@ -97,7 +97,7 @@ impl Claude {
             return req;
         }
         match super::invite_code::load() {
-            Some(code) => req.header("x-aegis-invite-code", code),
+            Some(code) => req.header(crate::providers::proxy_contract::INVITE_CODE_HEADER, code),
             None => req,
         }
     }
@@ -145,7 +145,7 @@ impl Claude {
         Ok(Claude {
             http,
             endpoint: PROXY_URL.to_string(),
-            auth: ("x-aegis-device-id".to_string(), device_id),
+            auth: (crate::providers::proxy_contract::DEVICE_ID_HEADER.to_string(), device_id),
             via_proxy: true,
         })
     }

--- a/aegis/src/providers/claude/mod.rs
+++ b/aegis/src/providers/claude/mod.rs
@@ -145,7 +145,10 @@ impl Claude {
         Ok(Claude {
             http,
             endpoint: PROXY_URL.to_string(),
-            auth: (crate::providers::proxy_contract::DEVICE_ID_HEADER.to_string(), device_id),
+            auth: (
+                crate::providers::proxy_contract::DEVICE_ID_HEADER.to_string(),
+                device_id,
+            ),
             via_proxy: true,
         })
     }

--- a/aegis/src/providers/mod.rs
+++ b/aegis/src/providers/mod.rs
@@ -1,5 +1,6 @@
 pub mod claude;
 pub mod device_id;
 pub mod invite_code;
+pub mod proxy_contract;
 pub mod stt_deepgram;
 pub mod tts_cartesia;

--- a/aegis/src/providers/proxy_contract.rs
+++ b/aegis/src/providers/proxy_contract.rs
@@ -1,0 +1,27 @@
+// Wire constants for the Aegis Cloudflare Worker proxy. The header strings
+// are the x-aegis-* literals used throughout proxy/src/index.ts;
+// code_format_valid mirrors CODE_RE in that file. Do not change these values;
+// users have codes and device IDs in flight.
+
+/// Header carrying the per-install UUID device identifier.
+pub const DEVICE_ID_HEADER: &str = "x-aegis-device-id";
+
+/// Header carrying the invite code for demo-tier access.
+pub const INVITE_CODE_HEADER: &str = "x-aegis-invite-code";
+
+/// Returns true if `s` is a plausible invite code format.
+/// Mirrors the proxy's CODE_RE: /^[A-Z0-9][A-Z0-9-]{6,62}[A-Z0-9]$/
+/// The proxy is the source of truth for expiry and device limits.
+pub fn code_format_valid(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    if !(8..=64).contains(&bytes.len()) {
+        return false;
+    }
+    let all_valid = bytes
+        .iter()
+        .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || *b == b'-');
+    if !all_valid {
+        return false;
+    }
+    bytes.first() != Some(&b'-') && bytes.last() != Some(&b'-')
+}

--- a/aegis/src/providers/stt_deepgram.rs
+++ b/aegis/src/providers/stt_deepgram.rs
@@ -88,9 +88,9 @@ impl SttDeepgram {
                 let mut req = self
                     .http
                     .post(token_url)
-                    .header("x-aegis-device-id", device_id);
+                    .header(super::proxy_contract::DEVICE_ID_HEADER, device_id);
                 if let Some(code) = super::invite_code::load() {
-                    req = req.header("x-aegis-invite-code", code);
+                    req = req.header(super::proxy_contract::INVITE_CODE_HEADER, code);
                 }
                 let proxy = req.send();
                 let _ = tokio::join!(dg, proxy);
@@ -117,9 +117,9 @@ impl SttDeepgram {
                 let mut req = self
                     .http
                     .post(token_url)
-                    .header("x-aegis-device-id", device_id);
+                    .header(super::proxy_contract::DEVICE_ID_HEADER, device_id);
                 if let Some(code) = super::invite_code::load() {
-                    req = req.header("x-aegis-invite-code", code);
+                    req = req.header(super::proxy_contract::INVITE_CODE_HEADER, code);
                 }
                 let resp = req.send().await?;
                 if !resp.status().is_success() {

--- a/aegis/src/providers/tts_cartesia.rs
+++ b/aegis/src/providers/tts_cartesia.rs
@@ -101,9 +101,9 @@ impl TtsCartesia {
                 let mut req = self
                     .http
                     .post(token_url)
-                    .header("x-aegis-device-id", device_id);
+                    .header(super::proxy_contract::DEVICE_ID_HEADER, device_id);
                 if let Some(code) = super::invite_code::load() {
-                    req = req.header("x-aegis-invite-code", code);
+                    req = req.header(super::proxy_contract::INVITE_CODE_HEADER, code);
                 }
                 let resp = req.send().await?;
                 if !resp.status().is_success() {

--- a/launcher/src-tauri/src/main.rs
+++ b/launcher/src-tauri/src/main.rs
@@ -1,5 +1,30 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
+// Wire constants for the Cloudflare Worker proxy. The launcher does not depend
+// on the aegis crate, so the headers are duplicated here and code_format_valid
+// mirrors CODE_RE from proxy/src/index.ts. If the wire values ever change,
+// update proxy/src/index.ts first, then this module and
+// aegis/src/providers/proxy_contract.rs together.
+mod proxy_contract {
+    pub const DEVICE_ID_HEADER: &str = "x-aegis-device-id";
+    pub const INVITE_CODE_HEADER: &str = "x-aegis-invite-code";
+
+    /// Mirrors the proxy's CODE_RE: /^[A-Z0-9][A-Z0-9-]{6,62}[A-Z0-9]$/
+    pub fn code_format_valid(s: &str) -> bool {
+        let bytes = s.as_bytes();
+        if !(8..=64).contains(&bytes.len()) {
+            return false;
+        }
+        let all_valid = bytes
+            .iter()
+            .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || *b == b'-');
+        if !all_valid {
+            return false;
+        }
+        bytes.first() != Some(&b'-') && bytes.last() != Some(&b'-')
+    }
+}
+
 #[cfg(unix)]
 use std::os::unix::process::CommandExt;
 use std::process::{Command, Stdio};
@@ -135,20 +160,11 @@ fn api_keys_status() -> std::collections::HashMap<String, bool> {
 /// junk before the proxy ever sees it. The proxy is the source of truth
 /// for expiry, device limits, and unknown codes.
 fn validate_code(code: &str) -> Result<(), &'static str> {
-    let bytes = code.as_bytes();
-    if !(8..=64).contains(&bytes.len()) {
-        return Err("invalid invite code format");
+    if proxy_contract::code_format_valid(code) {
+        Ok(())
+    } else {
+        Err("invalid invite code format")
     }
-    let valid_chars = bytes
-        .iter()
-        .all(|b| b.is_ascii_uppercase() || b.is_ascii_digit() || *b == b'-');
-    if !valid_chars {
-        return Err("invalid invite code format");
-    }
-    if bytes.first() == Some(&b'-') || bytes.last() == Some(&b'-') {
-        return Err("invalid invite code format");
-    }
-    Ok(())
 }
 
 /// Proxy endpoint that read-only-validates an invite code (no device binding,
@@ -191,8 +207,8 @@ async fn verify_invite_code(code: String) -> Result<(), String> {
     let device_id = device_id()?;
     let resp = reqwest::Client::new()
         .post(VERIFY_URL)
-        .header("x-aegis-device-id", device_id)
-        .header("x-aegis-invite-code", trimmed)
+        .header(proxy_contract::DEVICE_ID_HEADER, device_id)
+        .header(proxy_contract::INVITE_CODE_HEADER, trimmed)
         .send()
         .await
         .map_err(|_| "Couldn't reach the server. Check your connection.".to_string())?;


### PR DESCRIPTION
## Why

Run #26516352417 hung 5h41m on `notarytool submit --wait` inside `cargo tauri build` (no timeout) and hit GitHub's 6h cap. Build, sign, and bundle had finished in 19 min.

## What

- Stop passing `APPLE_ID` / `APPLE_PASSWORD` / `APPLE_TEAM_ID` to the build, so Tauri signs but skips its inline notarize.
- New step: `notarytool submit --wait --timeout 30m`, then `stapler staple` and `validate`. Dumps the notary log on any non-Accepted status.
- `timeout-minutes: 60` on the job as a backstop.
- Checksum moved after stapling.

Unsigned path is unchanged.

Drive-by: extract the `x-aegis-device-id` / `x-aegis-invite-code` headers into a `proxy_contract` module so the aegis crate and the launcher share constants instead of re-typing the wire string at six call sites.

## Notes

To recover the stuck release: re-run after merge, or check `xcrun notarytool history` for prior submissions that may have landed.
