### PR TITLE
release: v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). aegis f
 
 ## [Unreleased]
 
+## [0.1.8] - 2026-05-28
+
 ### Added
 
 - On-device ONNX intent classifier (`aegis/src/routelet.rs`) via tract. Replaces the per-turn Claude classifier call with a local SetFit model. Falls back to Claude only when calibrated confidence is below `ROUTELET_CONFIDENCE_THRESHOLD`.
 - `demo_routelet` bin (`demos/src/bin/demo_routelet.rs`) for hand-testing the classifier.
 - `PRIVACY.md` documenting what leaves the device and how on-device logging works.
 - `AEGIS_ROUTELET_LOG` env var to opt into redacted router logging at `~/.config/aegis/routelet_log.jsonl` (capped at 5000 lines).
+- Chat mode now includes a screenshot so Claude can see the user's screen and answer contextual questions ([#51](https://github.com/danielbusnz-lgtm/Aegis/pull/51)).
+- Onboarding prompts macOS for microphone, accessibility, and screen recording permissions on first launch.
 - SQLite + FTS5 conversation log (`aegis/src/providers/claude/history.rs`). Per-turn record + keyword search with porter stemming and BM25 ranking.
 - Tool-routing eval harness (`aegis/evals/runners/tool_routing.rs`). Runs cases from `aegis/evals/cases/tool_routing.json` through the live classifier and reports pass rate, per-category breakdown, and confusion matrix.
 - Cursor SVG hero in the project README.
@@ -23,6 +27,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). aegis f
 
 - Renamed `aegis/examples/` → `aegis/demos/`. Files renamed from `test_*.rs` → `demo_*.rs` (hand-run dev tools) and `bench_*.rs` (latency benchmarks). Each is now a `[[bin]]` entry in `Cargo.toml`; run with `cargo run --bin <name>`.
 - Dropped `AUDIO_POST_RELEASE_GRACE_MS` from 800 to 0 in `tuning.rs`.
+
+### Fixed
+
+- macOS `.dmg` ships signed and notarized again. The release workflow now notarizes the bundle out of band with a bounded `notarytool` wait, preventing the 6 hour hang that wedged `v0.1.7` ([#52](https://github.com/danielbusnz-lgtm/Aegis/pull/52)).
 
 ## [0.1.0]
 

--- a/launcher/src-tauri/tauri.conf.json
+++ b/launcher/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Aegis",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.aegis.settings",
   "build": {
     "frontendDist": "../src"


### PR DESCRIPTION
## Why

Cut v0.1.8 to ship the first signed and notarized macOS `.dmg` since the v0.1.7 workflow hung 5h41m on `notarytool submit --wait` and was killed at GitHub's 6h cap. The release pipeline fix landed in #52; this release exercises it end to end.

## What

- Bump `launcher/src-tauri/tauri.conf.json` from `0.1.7` to `0.1.8`.
- Roll the existing `[Unreleased]` block into `## [0.1.8]` in CHANGELOG, plus three new entries: chat-mode screenshot (#51), macOS onboarding permission prompts, and the notarize-out-of-band fix (#52).

## Test plan

Merge, tag `v0.1.8`, push. The tag push triggers the release workflow, which builds Linux/Windows/macOS, signs the macOS bundle, runs `notarytool submit --wait --timeout 30m`, staples the ticket, and drafts a GitHub release with the three artifacts attached.
