### PR TITLE
tuning: raise routelet gate threshold to 0.95

### DIFF
--- a/aegis/src/routelet/sample.rs
+++ b/aegis/src/routelet/sample.rs
@@ -28,6 +28,7 @@ fn append_record(path: &Path, line: &str, max_lines: usize) -> std::io::Result<(
             .open(path)?;
         writeln!(file, "{line}")?;
     }
+
     let contents = std::fs::read_to_string(path)?;
     let lines: Vec<&str> = contents.lines().collect();
     if lines.len() > max_lines {

--- a/aegis/src/tuning.rs
+++ b/aegis/src/tuning.rs
@@ -35,13 +35,16 @@ pub const TTS_FIRST_FLUSH_MIN_CHARS: usize = 12;
 // ────── routelet classifier ──────
 
 /// Minimum routelet confidence required to accept its prediction on-device.
-/// Below this threshold the turn falls back to the Claude classifier (one
-/// network round-trip) for a second opinion. Typical on-distribution
-/// confidence is above 0.9, so this threshold only fires on genuinely
-/// garbled or out-of-distribution input.
-/// ↑ defers more ambiguous turns to Claude (more accurate, adds latency).
-/// ↓ keeps more turns fully on-device (faster, accepts lower-confidence calls).
-pub const ROUTELET_CONFIDENCE_THRESHOLD: f32 = 0.55;
+/// Below this the turn falls back to the Claude classifier for a second opinion.
+///
+/// Set high on purpose. routelet's max-softmax saturates near 0.98 for almost
+/// everything, including garbled/out-of-distribution input, so a low gate never
+/// fired (see the deferral analysis in routelet/report). At 0.55 it deferred ~0%
+/// of OOD probes; at 0.95 it catches a meaningful share of them while deferring
+/// only ~1 to 2% of real in-distribution commands.
+/// ↑ defers more turns to Claude (catches more OOD, adds latency and cost).
+/// ↓ keeps more turns on-device (faster, but the gate stops catching OOD).
+pub const ROUTELET_CONFIDENCE_THRESHOLD: f32 = 0.95;
 
 /// Max distillation samples drained and POSTed in one uploader wakeup.
 /// ↑ fewer wakeups under bursty use. larger transient batch if the proxy is slow.


### PR DESCRIPTION
routelet's max-softmax saturates near 0.98 even on garbled/OOD input, so the old 0.55 confidence gate deferred ~0% of OOD probes to Claude, the safety net was inert. Raising it to 0.95 catches a meaningful share of OOD while deferring only ~1-2% of real in-distribution commands. Evidence: the deferral-tradeoff analysis in routelet/report. Also includes a stray blank line in sample.rs.