### PR TITLE
console: fix rustfmt and onboarding test after account merge

### DIFF
--- a/console/src-tauri/src/account.rs
+++ b/console/src-tauri/src/account.rs
@@ -90,12 +90,21 @@ pub async fn github_sign_in() -> Result<Account, String> {
         }
         let body: serde_json::Value = resp.json().await.unwrap_or(serde_json::Value::Null);
         if body.get("status").and_then(|v| v.as_str()) == Some("done") {
-            let token = body.get("token").and_then(|v| v.as_str()).unwrap_or_default();
+            let token = body
+                .get("token")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
             if token.is_empty() {
                 return Err("sign-in failed: empty token".to_string());
             }
-            let email = body.get("email").and_then(|v| v.as_str()).map(str::to_string);
-            let name = body.get("name").and_then(|v| v.as_str()).map(str::to_string);
+            let email = body
+                .get("email")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let name = body
+                .get("name")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
             // The file is what the running agent reads, so it's the required
             // write: a sign-in that doesn't land here didn't really happen.
             write_session_jwt_file(token)?;
@@ -118,8 +127,8 @@ pub async fn github_sign_in() -> Result<Account, String> {
 /// absent on setups without a Secret Service even when signed in.
 #[tauri::command]
 pub fn account_status() -> SessionStatus {
-    let signed_in =
-        session_jwt_path().is_some_and(|p| p.exists()) || keychain_get(SESSION_JWT_ACCOUNT).is_some();
+    let signed_in = session_jwt_path().is_some_and(|p| p.exists())
+        || keychain_get(SESSION_JWT_ACCOUNT).is_some();
     SessionStatus {
         signed_in,
         email: keychain_get(SESSION_EMAIL_ACCOUNT),

--- a/console/src-tauri/src/integrations.rs
+++ b/console/src-tauri/src/integrations.rs
@@ -21,7 +21,10 @@ pub async fn integrations_status() -> Result<serde_json::Value, String> {
         .map_err(|e| format!("failed to run aegis: {e}"))?;
 
     if !output.status.success() {
-        return Err(format!("aegis integrations-status exited with {}", output.status));
+        return Err(format!(
+            "aegis integrations-status exited with {}",
+            output.status
+        ));
     }
 
     serde_json::from_slice(&output.stdout).map_err(|e| format!("bad status json: {e}"))

--- a/console/src-tauri/src/keychain.rs
+++ b/console/src-tauri/src/keychain.rs
@@ -20,7 +20,9 @@ pub(crate) fn keychain_get(account: &str) -> Option<String> {
 /// Store `value` under `account`. Errors carry the account name for context.
 pub(crate) fn keychain_set(account: &str, value: &str) -> Result<(), String> {
     let entry = keyring::Entry::new(KEYRING_SERVICE, account).map_err(|e| e.to_string())?;
-    entry.set_password(value).map_err(|e| format!("save {account}: {e}"))
+    entry
+        .set_password(value)
+        .map_err(|e| format!("save {account}: {e}"))
 }
 
 /// Delete `account` if present. Best-effort: a missing entry or unavailable

--- a/console/tests/onboarding.test.js
+++ b/console/tests/onboarding.test.js
@@ -388,16 +388,16 @@ describe("api_keys_status prefill on load", () => {
 // ============================================================
 
 describe("gate: invite flow", () => {
-  test("empty invite code → blocked, hint set, #invite-code shakes, no save called", async () => {
-    const { invokeFn, codeInput, gateHint, cursorBtn, win } = await setup();
+  test("empty invite code → starts trial, advances to howto, no shake, no save", async () => {
+    const { invokeFn, codeInput, cursorBtn, win } = await setup();
 
     codeInput().value = "";
     click(cursorBtn());
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(win().classList.contains("show-howto")).toBe(false);
-    expect(gateHint().textContent).toBeTruthy();
-    expect(codeInput().classList.contains("shake")).toBe(true);
+    // Blank code is the free trial: advance to the hotkey card, no error shake.
+    expect(win().classList.contains("show-howto")).toBe(true);
+    expect(codeInput().classList.contains("shake")).toBe(false);
 
     const saveCalls = invokeFn.mock.calls.filter(([cmd]) => cmd === "save_invite_code");
     expect(saveCalls).toHaveLength(0);


### PR DESCRIPTION
The account squash left the new console modules unformatted (cargo fmt --check failed) and the blank-code onboarding vitest asserting the old blocked behavior. Formats the modules and updates the test for trial-start.