### PR TITLE
aegis: fix clippy on the portable build path

### DIFF
--- a/aegis/src/orchestrator.rs
+++ b/aegis/src/orchestrator.rs
@@ -504,6 +504,7 @@ async fn run_find_action(
 
 /// Dispatch the Chat path. Now includes screenshot for visual context.
 /// Text deltas land in the sentence channel which the TTS task pulls from.
+#[allow(clippy::too_many_arguments)]
 async fn run_chat(
     claude: &Claude,
     transcript: &str,

--- a/aegis/src/upgrade.rs
+++ b/aegis/src/upgrade.rs
@@ -101,15 +101,15 @@ fn console_candidates() -> Vec<PathBuf> {
     if let Ok(p) = std::env::var("AEGIS_CONSOLE_BIN") {
         candidates.push(PathBuf::from(p));
     }
-    if let Ok(exe) = std::env::current_exe() {
-        if let Some(dir) = exe.parent() {
-            candidates.push(dir.join("console"));
-            candidates.push(dir.join("Aegis"));
-            #[cfg(windows)]
-            {
-                candidates.push(dir.join("console.exe"));
-                candidates.push(dir.join("Aegis.exe"));
-            }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        candidates.push(dir.join("console"));
+        candidates.push(dir.join("Aegis"));
+        #[cfg(windows)]
+        {
+            candidates.push(dir.join("console.exe"));
+            candidates.push(dir.join("Aegis.exe"));
         }
     }
     for p in [


### PR DESCRIPTION
The lint job runs clippy on the --no-default-features path with -D warnings. Two errors surfaced once the fmt failure stopped masking them: run_chat over the arg limit (allow it, like the other dispatchers) and a collapsible if in upgrade.rs console_candidates (let-chain).