### PR TITLE
working-context: record every turn and add conversational recall

### DIFF
--- a/aegis/src/orchestrator.rs
+++ b/aegis/src/orchestrator.rs
@@ -339,7 +339,7 @@ fn run_one_turn(
     // ────── phase 4: branch on intent ──────
     let cancel_claude = barge_in.token();
     print!("claude: ");
-    rt.block_on(async {
+    let reply = rt.block_on(async {
         match intent {
             Intent::FindAction => {
                 eprintln!("[intent] → FindAction for: {:?}", transcript);
@@ -388,6 +388,7 @@ fn run_one_turn(
                     claude,
                     &transcript,
                     memory,
+                    working,
                     release_t,
                     &cancel_claude,
                     &sentence_tx,
@@ -415,6 +416,13 @@ fn run_one_turn(
             Intent::None => unreachable!("Intent::None is handled before dispatch"),
         }
     });
+    // Record the completed turn into the live working context for every intent,
+    // not just chat, so the next turn can reference what was said or done. None
+    // means a barge-in or error turn, which we skip.
+    if let Some(reply) = &reply {
+        working.record(&transcript, reply);
+        spawn_compaction(working, claude);
+    }
     // A turn that hit the trial wall during dispatch swallows its own Claude
     // error, so speak the upgrade line through the live TTS pipeline before we
     // close it. The browser sign-in was already kicked off at the call site.
@@ -472,7 +480,7 @@ async fn run_find_action(
     early_exit: &CancellationToken,
     cancel_claude: &CancellationToken,
     sentence_tx: &tokio::sync::mpsc::UnboundedSender<String>,
-) {
+) -> Option<String> {
     let early_exit_action = early_exit.clone();
     let action_cb = move |action| {
         eprintln!("[timing] claude first response → {:?}", release_t.elapsed());
@@ -489,14 +497,22 @@ async fn run_find_action(
         _ = cancel_claude.cancelled() => {
             eprintln!("[barge-in] find_action aborted at {:?}", release_t.elapsed());
             let _ = sentence_tx;
+            None
         }
         result = claude.find_action(
             transcript, screenshot_b64,
             x as i64, y as i64, w as i64, h as i64,
             action_cb,
         ) => {
-            if let Err(e) = result {
-                eprintln!("[find_action] failed: {e}");
+            match result {
+                Ok(actions) if !actions.is_empty() => {
+                    Some("(performed an on-screen action)".to_string())
+                }
+                Ok(_) => None,
+                Err(e) => {
+                    eprintln!("[find_action] failed: {e}");
+                    None
+                }
             }
         }
     }
@@ -514,7 +530,7 @@ async fn run_chat(
     release_t: std::time::Instant,
     cancel_claude: &CancellationToken,
     sentence_tx: &tokio::sync::mpsc::UnboundedSender<String>,
-) {
+) -> Option<String> {
     let profile = memory.as_prompt_block();
     let convo = working.as_prompt_block();
     let mut helper = StreamHelper::new(sentence_tx.clone(), release_t);
@@ -522,6 +538,7 @@ async fn run_chat(
         biased;
         _ = cancel_claude.cancelled() => {
             eprintln!("[barge-in] chat aborted at {:?}", release_t.elapsed());
+            None
         }
         result = claude.chat(
             transcript, screenshot_b64, profile.as_deref(), convo.as_deref(),
@@ -533,14 +550,12 @@ async fn run_chat(
                     use std::io::Write;
                     std::io::stdout().flush().ok();
                     helper.flush_tail();
-                    // Record the completed turn into the live working context so
-                    // the next turn can reference it. Off the action path (the
-                    // reply has already streamed to TTS). Barge-in / error turns
-                    // fall through here and are intentionally not recorded.
-                    working.record(transcript, &final_text);
-                    spawn_compaction(working, claude);
+                    Some(final_text)
                 }
-                Err(e) => eprintln!("[chat] failed: {e}"),
+                Err(e) => {
+                    eprintln!("[chat] failed: {e}");
+                    None
+                }
             }
         }
     }
@@ -582,7 +597,7 @@ async fn run_integration(
     release_t: std::time::Instant,
     cancel_claude: &CancellationToken,
     sentence_tx: &tokio::sync::mpsc::UnboundedSender<String>,
-) {
+) -> Option<String> {
     let profile = memory.as_prompt_block();
     let mut helper = StreamHelper::new(sentence_tx.clone(), release_t);
     let dispatch = |name: &str, input: &serde_json::Value| {
@@ -596,6 +611,7 @@ async fn run_integration(
         biased;
         _ = cancel_claude.cancelled() => {
             eprintln!("[barge-in] integration aborted at {:?}", release_t.elapsed());
+            None
         }
         result = claude.integration(
             transcript,
@@ -610,8 +626,12 @@ async fn run_integration(
                     use std::io::Write;
                     std::io::stdout().flush().ok();
                     helper.flush_tail();
+                    Some(final_text)
                 }
-                Err(e) => eprintln!("[integration] failed: {e}"),
+                Err(e) => {
+                    eprintln!("[integration] failed: {e}");
+                    None
+                }
             }
         }
     }
@@ -624,25 +644,32 @@ async fn run_memory(
     claude: &Claude,
     transcript: &str,
     memory: &crate::providers::claude::MemoryStore,
+    working: &crate::providers::claude::WorkingContext,
     release_t: std::time::Instant,
     cancel_claude: &CancellationToken,
     sentence_tx: &tokio::sync::mpsc::UnboundedSender<String>,
-) {
+) -> Option<String> {
+    let convo = working.as_prompt_block();
     let mut helper = StreamHelper::new(sentence_tx.clone(), release_t);
     tokio::select! {
         biased;
         _ = cancel_claude.cancelled() => {
             eprintln!("[barge-in] memory aborted at {:?}", release_t.elapsed());
+            None
         }
-        result = claude.memory(transcript, memory, |delta| helper.push_delta(delta)) => {
+        result = claude.memory(transcript, memory, convo.as_deref(), |delta| helper.push_delta(delta)) => {
             match result {
                 Ok(final_text) => {
                     print!("{final_text}");
                     use std::io::Write;
                     std::io::stdout().flush().ok();
                     helper.flush_tail();
+                    Some(final_text)
                 }
-                Err(e) => eprintln!("[memory] failed: {e}"),
+                Err(e) => {
+                    eprintln!("[memory] failed: {e}");
+                    None
+                }
             }
         }
     }
@@ -665,7 +692,7 @@ async fn run_agent(
     early_exit: &CancellationToken,
     cancel_claude: &CancellationToken,
     sentence_tx: &tokio::sync::mpsc::UnboundedSender<String>,
-) {
+) -> Option<String> {
     let take_screenshot = move || -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
         let (cx, cy, cw, ch) = screenshot::active_workspace_geometry()
             .map(|g| (g.0, g.1, g.2 as i32, g.3 as i32))
@@ -725,6 +752,7 @@ async fn run_agent(
         biased;
         _ = cancel_claude.cancelled() => {
             eprintln!("[barge-in] agent aborted at {:?}", release_t.elapsed());
+            None
         }
         result = cursor_task => {
             match result {
@@ -733,8 +761,12 @@ async fn run_agent(
                     use std::io::Write;
                     std::io::stdout().flush().ok();
                     helper.flush_tail();
+                    Some(final_text)
                 }
-                Err(e) => eprintln!("[agent-loop] failed: {e}"),
+                Err(e) => {
+                    eprintln!("[agent-loop] failed: {e}");
+                    None
+                }
             }
         }
     }

--- a/aegis/src/providers/claude/memory.rs
+++ b/aegis/src/providers/claude/memory.rs
@@ -163,6 +163,7 @@ impl Claude {
         &self,
         transcript: &str,
         store: &MemoryStore,
+        conversation: Option<&str>,
         mut on_text_delta: T,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>
     where
@@ -214,6 +215,13 @@ impl Claude {
                         },
                         "required": ["key"]
                     }
+                },
+                {
+                    "name": "recall_conversation",
+                    "description": "User is asking about the conversation you are having right \
+                        now, not a stored fact. E.g. 'what did I just ask you', 'what were we \
+                        talking about', 'what did you just say'. Takes no input.",
+                    "input_schema": { "type": "object", "properties": {} }
                 }
             ],
             "tool_choice": { "type": "any" },
@@ -338,6 +346,10 @@ impl Claude {
                 on_text_delta(&reply);
                 Ok(reply)
             }
+            Some("recall_conversation") => {
+                self.answer_from_conversation(transcript, conversation, on_text_delta)
+                    .await
+            }
             other => {
                 let reply = format!(
                     "I wasn't sure what to do with that (router returned {:?}). Try \
@@ -348,6 +360,84 @@ impl Claude {
                 Ok(reply)
             }
         }
+    }
+
+    /// Answer a question about the live conversation from the working-context
+    /// buffer, not the facts store. A second text-only Claude call: the router
+    /// already spent one deciding this was conversational recall.
+    async fn answer_from_conversation<T>(
+        &self,
+        transcript: &str,
+        conversation: Option<&str>,
+        mut on_text_delta: T,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>
+    where
+        T: FnMut(&str),
+    {
+        let convo = conversation.unwrap_or("");
+        if convo.trim().is_empty() {
+            let reply = "We just started talking, so there isn't anything earlier to recall yet.";
+            on_text_delta(reply);
+            return Ok(reply.to_string());
+        }
+        let body = serde_json::json!({
+            "model": "claude-haiku-4-5",
+            "max_tokens": 300,
+            "stream": true,
+            "system": [{
+                "type": "text",
+                "text": format!(
+                    "You are aegis, a voice assistant. The user is asking about the conversation \
+                     you have been having with them. Answer from the transcript below in one or two \
+                     short spoken sentences, plain prose, no markdown. If the answer is not in it, \
+                     say so briefly.\n\nConversation so far:\n{}",
+                    convo
+                )
+            }],
+            "messages": [{ "role": "user", "content": transcript }]
+        });
+
+        let response = self
+            .apply_auth(self.http.post(&self.endpoint))
+            .header("anthropic-version", "2023-06-01")
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body_text = response.text().await.unwrap_or_default();
+            crate::upgrade::on_proxy_error(status.as_u16(), &body_text);
+            return Err(format!("recall_conversation API error {}: {}", status, body_text).into());
+        }
+
+        let mut stream = response.bytes_stream();
+        let mut buffer = String::new();
+        let mut text = String::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            let s = std::str::from_utf8(&chunk)?;
+            buffer.push_str(s);
+            while let Some(idx) = buffer.find("\n\n") {
+                let frame: String = buffer.drain(..idx + 2).collect();
+                for line in frame.lines() {
+                    let Some(data) = line.strip_prefix("data: ") else {
+                        continue;
+                    };
+                    let Ok(event) = serde_json::from_str::<serde_json::Value>(data) else {
+                        continue;
+                    };
+                    if event["type"].as_str() == Some("content_block_delta")
+                        && event["delta"]["type"].as_str() == Some("text_delta")
+                        && let Some(t) = event["delta"]["text"].as_str()
+                    {
+                        text.push_str(t);
+                        on_text_delta(t);
+                    }
+                }
+            }
+        }
+        Ok(text)
     }
 }
 
@@ -364,6 +454,9 @@ value.\n\
 - recall_fact(key): user is asking \"what's my X\" or \"what did I tell \
 you about X\". Provide the snake_case key you'd expect a prior store \
 to have used.\n\
+- recall_conversation(): user is asking about the conversation happening \
+right now, not a stored fact. E.g. \"what did I just ask you\", \"what \
+were we talking about\", \"what did you just say\".\n\
 \n\
 Examples:\n\
   \"remember my favorite color is blue\" → store_fact(favorite_color, blue)\n\
@@ -372,6 +465,8 @@ Examples:\n\
   \"what's my favorite color\" → recall_fact(favorite_color)\n\
   \"where do I live\" → recall_fact(home_city)\n\
   \"what am I allergic to\" → recall_fact(allergic_to)\n\
+  \"what did I just ask you\" → recall_conversation()\n\
+  \"what were we talking about\" → recall_conversation()\n\
 \n\
 Always call a tool. Never respond with plain text."
 }


### PR DESCRIPTION
Records every voice turn into the live working context (not just chat), and adds a recall_conversation tool to the memory router so 'what did I just ask you' answers from the buffer instead of the facts store. Verified live: ask a couple of turns, then 'what was my first question' answers correctly.