### PR TITLE
stt: keyterm-boost Peeky on nova-3

### DIFF
--- a/peeky/src/providers/stt_deepgram.rs
+++ b/peeky/src/providers/stt_deepgram.rs
@@ -186,10 +186,15 @@ impl SttDeepgram {
         // format declared here to match what we send. interim_results=true
         // lets us return the latest partial transcript the moment the user
         // releases, without waiting for Deepgram's final commit.
+        //
+        // keyterm boosts recognition of the product name "Peeky" (Nova-3 keyterm
+        // prompting). It mis-transcribes often as a bare proper noun (peaky,
+        // picky, peeking), which matters because the agent cue starts with it.
         let url = format!(
             "wss://api.deepgram.com/v1/listen?model=nova-3&language=en\
              &encoding=linear16&sample_rate={}&channels={}\
-             &punctuate=true&interim_results=true&smart_format=true",
+             &punctuate=true&interim_results=true&smart_format=true\
+             &keyterm=Peeky",
             sample_rate, channels
         );
 


### PR DESCRIPTION
Boosts recognition of the product name "Peeky" by adding Nova-3 keyterm
prompting to the Deepgram streaming URL.

## Why
"Peeky" is a short proper noun that mis-transcribes often (peaky, picky,
peeking). That matters for the upcoming explicit agent cue, which starts with
the word, but it also helps any utterance that names the product.

## Change
One query param on the existing Nova-3 WebSocket URL: `&keyterm=Peeky`.

- `keyterm` is the correct boost param for Nova-3 streaming (the older
  `keywords` param returns HTTP 400 on nova-3; this avoids it).
- Purely additive. No new code paths, no deps, no request-body change.

## Verification
`cargo check` and `cargo fmt` clean. Keyterm is a server-side effect, so the
recognition improvement itself needs a live mic test (say "peeky agent" and
check the transcript); it cannot be unit-tested.
