### PR TITLE
orchestrator: fall back to chat when find_action emits no action

### DIFF
--- a/peeky/src/orchestrator.rs
+++ b/peeky/src/orchestrator.rs
@@ -343,7 +343,7 @@ fn run_one_turn(
         let reply = match intent {
             Intent::FindAction => {
                 eprintln!("[intent] → FindAction for: {:?}", transcript);
-                run_find_action(
+                let reply = run_find_action(
                     claude,
                     &transcript,
                     &resized_b64,
@@ -356,7 +356,29 @@ fn run_one_turn(
                     &cancel_claude,
                     &sentence_tx,
                 )
-                .await
+                .await;
+                // A turn must never end in silence. A FindAction that emitted
+                // no action (misroute, forbidden tool call, provider error)
+                // re-routes the same transcript to Chat, which can answer
+                // questions like "can you see my screen?". Chat never routes
+                // back here, so this cannot loop. A barge-in stays silent on
+                // purpose: the user cut the turn off themselves.
+                if reply.is_none() && !cancel_claude.is_cancelled() {
+                    eprintln!("[find_action] no action emitted; falling back to Chat");
+                    run_chat(
+                        claude,
+                        &transcript,
+                        &resized_b64,
+                        memory,
+                        working,
+                        release_t,
+                        &cancel_claude,
+                        &sentence_tx,
+                    )
+                    .await
+                } else {
+                    reply
+                }
             }
             Intent::Chat => {
                 eprintln!("[intent] → Chat for: {:?}", transcript);


### PR DESCRIPTION
## Problem

A FindAction turn that emits no action ends in silence. Three ways to get there: routelet misroutes a chat question to FindAction, Claude calls the forbidden screenshot action, or the API errors. The user asks something and hears nothing. Reproduced live with "Can you see my screen?" (routelet says FindAction at 0.98, Claude then calls screenshot, turn dies).

## Fix

In the dispatch arm, when run_find_action returns None and the turn was not barged in, re-route the same transcript to run_chat. Chat receives the screenshot too, so capability questions get a real spoken answer. Chat never routes back to FindAction, so no loop. Barge-in stays silent on purpose.

## Verified

Live on macOS against the running agent:

- "Can you see my screen?" before: dead air. After: forbidden screenshot call still logged, fallback fires, Peeky answers by describing the screen.
- Also covered a 429 trial_exhausted turn: error, fallback, upgrade prompt spoken. No silent turns observed since.

Follow-up (separate): routelet retrain with screen-mention chat questions as hard negatives, so these route to Chat directly instead of through the fallback.
